### PR TITLE
Add --no-group to rsync

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -2364,7 +2364,7 @@ rsync_command() {
 
     local SYNC_LOCK=$SBOPKGTMP/sbopkg_sync.lck
 
-    rsync --archive --delete --no-owner --exclude="*.sbopkg" \
+    rsync --archive --delete --no-owner --no-group --exclude="*.sbopkg" \
         $RSYNCFLAGS $REPO_LINK/ $REPO_DIR/
     case $? in
         35)


### PR DESCRIPTION
So that the files and directories are not owned by "users" group, but
root.