### PR TITLE
sqg: Added a simple filesystem cache.

### DIFF
--- a/src/usr/libexec/sbopkg/sqg/functions
+++ b/src/usr/libexec/sbopkg/sqg/functions
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# use filesystem for caching SlackBuilds
+SQG_TMP_DIR=${SQG_TMP_DIR:-/tmp/sqg}
+
 sanity_checks () {
   if [ ! -e "$SBOPKG_CONF" ]; then
     echo "$SBOPKG_CONF not found."
@@ -21,6 +24,14 @@ sanity_checks () {
     echo "Check the configurable variables at the top of the script."
     exit 1
   fi
+
+  if [[ ! -d "$SQL_TMP_DIR" ]]; then
+    echo "ERROR: Directory $SQG_TMP_DIR not writable."
+    exit 1
+  fi
+
+  rm -rf "$SQG_TMP_DIR"
+  mkdir -p "$SQG_TMP_DIR"
 }
 
 has_parallel () {
@@ -74,8 +85,14 @@ search_package () {
   local REPO_DIR="$1"
   local SRCHAPP="$2"
 
-  cd $REPO_DIR
-  PKGPATH=($(find -type d -mindepth 2 -maxdepth 2 -name "$SRCHAPP" | sort))
+  if [[ -f "$SQG_TMP_DIR/$SRCHAPP" ]]; then
+    PKGPATH=$(cat "$SQG_TMP_DIR/$SRCHAPP")
+  else
+    cd $REPO_DIR
+    PKGPATH=($(find -type d -mindepth 2 -maxdepth 2 -name "$SRCHAPP" | sort))
+    echo "$PKGPATH" > "$SQG_TMP_DIR/$SRCHAPP"
+  fi
+
   if [ -z "$PKGPATH" ]; then
     return 1
   else

--- a/src/usr/libexec/sbopkg/sqg/functions
+++ b/src/usr/libexec/sbopkg/sqg/functions
@@ -25,11 +25,6 @@ sanity_checks () {
     exit 1
   fi
 
-  if [[ ! -d "$SQL_TMP_DIR" ]]; then
-    echo "ERROR: Directory $SQG_TMP_DIR not writable."
-    exit 1
-  fi
-
   rm -rf "$SQG_TMP_DIR"
   mkdir -p "$SQG_TMP_DIR"
 }


### PR DESCRIPTION
Simple filesystem cache which is approx. 5 times faster on a 8 cores test.

**Without filesystem cache**
time sqg -a -j 8
Processing all SlackBuilds in the SBo/14.2 repository...
Computers / CPU cores / Max jobs to run
1:local / 8 / 8

Computer:jobs running/jobs completed/%of started jobs/Average seconds to complete
ETA: 0s Left: 0 AVG: 0.05s  local:0/6421/100%/0.1s      
Done.

real	5m41.508s
user	13m57.566s
sys	19m40.116s

**With filesystem cache (/tmp)**
time sqg -a -j 8
Processing all SlackBuilds in the SBo/14.2 repository...
Computers / CPU cores / Max jobs to run
1:local / 8 / 8

Computer:jobs running/jobs completed/%of started jobs/Average seconds to complete
ETA: 0s Left: 0 AVG: 0.01s  local:0/6421/100%/0.0s     
Done.

real	1m5.857s
user	2m44.081s
sys	2m46.688s