### PR TITLE
Use correct SlackBuild file name to build package

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -3412,6 +3412,8 @@ process_package() {
     mkdir -p $SB_OUTPUT
 
     cd $REPO_DIR/$PKGPATH
+    mv $PKGNAME.SlackBuild $PKGNAME.SlackBuild.original
+    cp $PKGNAME.SlackBuild.build $PKGNAME.SlackBuild
 
     # Start the actual build
     # We loop here to enable a 'retry' if anything goes wrong with the build
@@ -3475,6 +3477,7 @@ process_package() {
 
     # Cleanup
     cd $REPO_DIR/$PKGPATH
+    mv $PKGNAME.SlackBuild.original $PKGNAME.SlackBuild
     rm -f $PKGNAME.{info,SlackBuild}.build
     rm -f options.build
 
@@ -3499,10 +3502,10 @@ build_package() {
             # deleting too much or leaving garbage behind us), a nice
             # approach is to use sbopkg's own temp directory.
             export TMP=$SBOPKGTMP
-            nice -n ${NICE:-10} sh $PKGNAME.SlackBuild.build
+            nice -n ${NICE:-10} sh $PKGNAME.SlackBuild
             echo "Cleaning up..."
         else
-            nice -n ${NICE:-10} sh $PKGNAME.SlackBuild.build
+            nice -n ${NICE:-10} sh $PKGNAME.SlackBuild
         fi
     )
 }


### PR DESCRIPTION
During package creation, most SlackBuilds copy the .SlackBuild file to /usr/doc/<pkg>/.  Previously, sbopkg would cause the "original" SlackBuild instead of the "local" SlackBuild with user edits to be copied to the documentation directory.  Now, sbopkg backs up the original SlackBuild to $PKGNAME.SlackBuild.original before building the package.

Old behavior:
1. Original (upstream) SlackBuild is named $PKGNAME.SlackBuild.
2. User optionally defines custom SlackBuild in $PKGNAME.SlackBuild.sbopkg
3. sbopkg asks user to use Original or Local SlackBuild, and copies $PKGNAME.SlackBuild or $PKGNAME.SlackBuild.sbopkg to $PKGNAME.SlackBuild.build, respectively.
4. sbopkg builds package (which includes copying SlackBuild to /usr/doc/).
5. sbopkg removes *.build files

New behavior:
1. Original (upstream) SlackBuild is named $PKGNAME.SlackBuild.
2. User optionally defines custom SlackBuild in $PKGNAME.SlackBuild.sbopkg
3. sbopkg asks user to use Original or Local SlackBuild, and copies $PKGNAME.SlackBuild or $PKGNAME.SlackBuild.sbopkg to $PKGNAME.SlackBuild.build, respectively.
4. sbopkg backs up original SlackBuild by moving $PKGNAME.SlackBuild to $PKGNAME.SlackBuild.original
5. sbopkg copies $PKGNAME.SlackBuild.build to $PKGNAME.SlackBuild.
6. sbopkg builds package (which includes copying SlackBuild to /usr/doc/).
7. sbopkg restores original SlackBuild by moving $PKGNAME.SlackBuild.original to $PKGNAME.SlackBuild
8. sbopkg removes *.build files