### PR TITLE
Fix bug in updates_compare_versions()

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -971,14 +971,14 @@ updates_compare_versions() {
     # 1.2.50 build 4, the argument list is
     # 1 2 3 7 1 2 50 4
     # Prints -1 if the "left" package is newer (not an update), 0 if
-    # the version is unchanged, 1 if the "left" package is newer.
+    # the version is unchanged, 1 if the "left" package is older.
 
     local COUNT=$(($# / 2))
     local i RESULT=0
     local LEFT RIGHT
 
     for ((i=1; i<=$COUNT; i++)); do
-        eval LEFT=\$$i
+        eval LEFT=\${$i}
         eval RIGHT=\${$(($i + $COUNT))}
         if [[ 10#$LEFT -lt 10#$RIGHT ]]; then
             RESULT=1


### PR DESCRIPTION
### Problem
Since Mousepad was updated to development version with git SHA1 as version string, I've been getting unexpected output when running `sbopkg -c`:
```
mousepad:
  INSTALLED PACKAGE IS NEWER THAN REPO
  Installed version:  mousepad-823215f511ee49176fcab7565bbf498b1a88e9b4-x86_64-1_SBo
  Repo version:  mousepad-823215f511ee49176fcab7565bbf498b1a88e9b4-x86_64-1_SBo
```
Both versions are exactly the same, so why is there a potential update reported?

### Investigation
In case of Mousepad the function `updates_compare_versions()` is called with the following 20 arguments: `823215 511 49176 7565 498 1 88 9 4 1 823215 511 49176 7565 498 1 88 9 4 1`. After adding some debug prints inside the function, this is the effect:
```
count = 10
_____ i = 1 _____
LEFT = 823215
RIGHT = 823215
_____ i = 2 _____
LEFT = 511
RIGHT = 511
_____ i = 3 _____
LEFT = 49176
RIGHT = 49176
_____ i = 4 _____
LEFT = 7565
RIGHT = 7565
_____ i = 5 _____
LEFT = 498
RIGHT = 498
_____ i = 6 _____
LEFT = 1
RIGHT = 1
_____ i = 7 _____
LEFT = 88
RIGHT = 88
_____ i = 8 _____
LEFT = 9
RIGHT = 9
_____ i = 9 _____
LEFT = 4
RIGHT = 4
_____ i = 10 _____
LEFT = 8232150
RIGHT = 1
```
In the final loop iteration `8232150` is the value of `$1` concatenated with digit `0` instead of expected value of `$10`. `LEFT` is greater than `RIGHT`, so the function returns `-1`.

### Conclusion
Loop index `$i` needs to be protected by curly braces in `eval` statement for variable `LEFT`.

### Testing
I applied my patch to my `sbopkg` installation and ran `sbopkg -c` again. This time Mousepad was not reported as a potential update, but remaining potential updates were reported correctly.