### PR TITLE
Fix parsing errors with shellcheck.

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -218,7 +218,7 @@ load_repositories() {
         # Reading from $FILE...
         while read LINE; do
             grep -q '#' <<< "$LINE" && continue
-            eval TMPARRAY=( "$LINE" )
+            eval "TMPARRAY=( $LINE )"
             [[ ${#TMPARRAY[@]} -eq 0 ]] && continue;
             # Sanity checks
             # these two assignments work around a bash3-4 incompatibility
@@ -3062,11 +3062,11 @@ get_source() {
             # inside file names.
             # We know that we could obtain the same result faster by mangling
             # with IFS, but the resulting code was a bit too hacky.
-            eval SRCNAME=( $(
+            eval "SRCNAME=( $(
                 while read LINE; do
-                    printf '%q ' "$LINE"
-                done <<< "$SRCNAME"
-            ) )
+                    printf '%q ' $LINE
+                done <<< $SRCNAME
+            ) )"
 
             check_source $PKG ${MD5SUM[$i]} "${SRCNAME[$i]}"
             case $? in


### PR DESCRIPTION
Fixes shellcheck parsing errors by using safer quoting practices with eval. I tested this here and found no change in behavior, but a review would be appreciated!
```
    Line 217:
        for FILE in $SBOPKG_REPOS_D/*.repo; do
        ^-- SC1009: The mentioned syntax error was in this for loop.

    Line 219:
            while read LINE; do
            ^-- SC1073: Couldn't parse this while loop. Fix to allow more checks.
                             ^-- SC1061: Couldn't find 'done' for this 'do'.

    Line 221:
                eval TMPARRAY=( "$LINE" )
                              ^-- SC1036: '(' is invalid here. Did you forget to escape it?
                              ^-- SC1062: Expected 'done' matching previously mentioned 'do'.
                              ^-- SC1072: Expected 'done'. Fix any mentioned problems and try again.
                              ^-- SC1098: Quote/escape special characters when using eval, e.g. eval "a=(b)".

    Line 3054:
        for i in ${!MD5SUM[@]}; do
        ^-- SC1009: The mentioned syntax error was in this for loop.

    Line 3056:
            while :; do
            ^-- SC1073: Couldn't parse this while loop. Fix to allow more checks.
                     ^-- SC1061: Couldn't find 'done' for this 'do'.

    Line 3065:
                eval SRCNAME=( $(
                             ^-- SC1036: '(' is invalid here. Did you forget to escape it?
                             ^-- SC1062: Expected 'done' matching previously mentioned 'do'.
                             ^-- SC1072: Expected 'done'. Fix any mentioned problems and try again.
                             ^-- SC1098: Quote/escape special characters when using eval, e.g. eval "a=(b)".
```
Also see. https://github.com/koalaman/shellcheck/wiki/SC1098