### PR TITLE
sqg: use the configs from /etc

### DIFF
--- a/src/usr/sbin/sqg
+++ b/src/usr/sbin/sqg
@@ -31,6 +31,10 @@
 
 SBOPKG_CONF=${SBOPKG_CONF:-/etc/sbopkg/sbopkg.conf}
 
+if [ -e "${SBOPKG_CONF}" ] ; then
+	source "${SBOPKG_CONF}"
+fi
+
 ### NO CHANGES SHOULD BE NECESSARY BELOW THIS LINE ###
 
 # source all sqg functions


### PR DESCRIPTION
if I have set a different version or repo, then sqg ought to just use
those new variables. It's every install that I have to add this because
I switch sbopkg.conf to "SBo-git"/"current", and then `sqg` can't find
the SBo/14.2 or whatever repo.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>