### PR TITLE
Add update ability for -current repo

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -2432,6 +2432,23 @@ rsync_command() {
     rm -f $SYNC_LOCK
 }
 
+current_check_updates() {
+    # This function checks for updates if repository is set to -current.
+
+    local URL BRANCH REMOTE LOCAL
+    
+    eval $(sed 's/^\(.*\)@\(.*\)$/URL=\1; BRANCH=\2/g' <<< $REPO_LINK)
+
+    cd $REPO_DIR
+    REMOTE=$(git ls-remote $URL $BRANCH | cut -f 1)
+    LOCAL=$(git rev-parse HEAD)
+    # If the remote has changed, wipe the local version
+    if [[ $REMOTE != $LOCAL ]]; then
+        cd ..
+        rm -fR $REPO_DIR
+    fi
+}
+
 git_command() {
     # This function synchronizes a local git repository with upstream.
 
@@ -2441,6 +2458,10 @@ git_command() {
     eval $(sed 's/^\(.*\)@\(.*\)$/URL=\1; BRANCH=\2/g' <<< $REPO_LINK)
 
     CWD=$(pwd)
+    # If -CURRENT, handle correctly
+    if [[ $REPO_BRANCH == "current" ]]; then
+        current_check_updates
+    fi 
     # Create the repository if needed
     if [[ ! -d $REPO_DIR/.git ]]; then
         mkdir -p $REPO_DIR

--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -2436,7 +2436,7 @@ current_check_updates() {
     # This function checks for updates if repository is set to -current.
 
     local URL BRANCH REMOTE LOCAL
-    
+
     eval $(sed 's/^\(.*\)@\(.*\)$/URL=\1; BRANCH=\2/g' <<< $REPO_LINK)
 
     cd $REPO_DIR
@@ -2459,9 +2459,11 @@ git_command() {
 
     CWD=$(pwd)
     # If -CURRENT, handle correctly
-    if [[ $REPO_BRANCH == "current" ]]; then
-        current_check_updates
-    fi 
+    if [[ $REPO_NAME == "SBo-git" ]]; then
+        if [[ $REPO_BRANCH == "current" ]]; then
+            current_check_updates
+        fi
+    fi
     # Create the repository if needed
     if [[ ! -d $REPO_DIR/.git ]]; then
         mkdir -p $REPO_DIR


### PR DESCRIPTION
Since the -current repo is recreated with every update, we have to completely redo the clone every time. This pull request causes Sync to check if our local SBo-git repo is different from the upstream one, and wipe the repo out so we can re-pull it on changes.

I suppose this could be modified to work off a setting in sbopkg.conf so the user can configure if they want this behavior, but I really don't see a situation in which they would initiate a Sync and not want to get the latest look if they can. Plus, it double-checks to not re-pull the repo unless something has changed, so...