### PR TITLE
sbopkg: Correct setting REPO_DIR variable for local repos

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -1088,6 +1088,9 @@ set_repo_vars() {
 
             if [[ $REPO_TOOL = "rsync" || $REPO_TOOL = "git" ]]; then
                 checkout_${REPO_TOOL}_branch
+            else
+                # In case of local repo ensure REPO_DIR ends with a branch.
+                REPO_DIR=$REPO_ROOT/$REPO_NAME/$REPO_BRANCH
             fi
 
             # If the user specified a custom tag, use that one instead.


### PR DESCRIPTION
This is a fix for issue  #57. Or at least my suggestion how to handle it.

[`set_repo_vars()`](https://github.com/sbopkg/sbopkg/blob/c0dfa99f28d17aa956d8efef3e457c1fb0a51595/src/usr/sbin/sbopkg#L1069) is setting `REPO_DIR=$REPO_ROOT/$REPO_NAME` instead of `REPO_DIR=$REPO_ROOT/$REPO_NAME/$REPO_BRANCH`. The branch suffix is not needed if `REPO_TOOL` is `git`. It is required when `REPO_TOOL` is `rsync`, and in that case it is added by [`checkout_rsync_branch()`](https://github.com/sbopkg/sbopkg/blob/c0dfa99f28d17aa956d8efef3e457c1fb0a51595/src/usr/sbin/sbopkg#L1011) function. The branch suffix is also required when `REPO_TOOL` is unset, but in that case it wasn't added anywhere.