### PR TITLE
sbopkg: Move SRCNAME evaluation outside loop for performance

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -3106,22 +3106,23 @@ get_source() {
 
     echo | tee -a $TMPSUMMARYLOG
     echo "$PKG:" | tee -a $TMPSUMMARYLOG
+
+    SRCNAME=$(get_source_names --placeholder $INFO)
+    # Put SRCNAME lines into array elements.
+    # This is a little bit involved since it has to deal with spaces
+    # inside file names.
+    # We know that we could obtain the same result faster by mangling
+    # with IFS, but the resulting code was a bit too hacky.
+    eval "SRCNAME=( $(
+        while read LINE; do
+            printf '%q ' $LINE
+        done <<< $SRCNAME
+    ) )"
+
     for i in ${!MD5SUM[@]}; do
         TWGETFLAGS=$WGETFLAGS
         while :; do
             cd "$CWD"
-            SRCNAME=$(get_source_names --placeholder $INFO)
-
-            # Put SRCNAME lines into array elements.
-            # This is a little bit involved since it has to deal with spaces
-            # inside file names.
-            # We know that we could obtain the same result faster by mangling
-            # with IFS, but the resulting code was a bit too hacky.
-            eval "SRCNAME=( $(
-                while read LINE; do
-                    printf '%q ' $LINE
-                done <<< $SRCNAME
-            ) )"
 
             check_source $PKG ${MD5SUM[$i]} "${SRCNAME[$i]}"
             case $? in


### PR DESCRIPTION
While building packages with a large number of sources (such as rust
packages), it was noticed that the source file MD5SUM verification was
slow.  This was due to setting and modifying the SRCNAME variable inside
the loop that checks the MD5SUM of every source file.  Because the
SRCNAME variable is loop invariant, move its evaluation to outside the
loop.  This drastically speeds up the verification phase.