### PR TITLE
Fix sqg detection of which repo it should use

### DIFF
--- a/src/usr/libexec/sbopkg/sqg/functions
+++ b/src/usr/libexec/sbopkg/sqg/functions
@@ -27,7 +27,7 @@ sanity_checks () {
   fi
 
   # check whether we are using git or rsync
-  if [ -d $REPO_ROOT/$REPO_NAME/.git ]; then
+  if [ $REPO_BRANCH == "master" ] || [ $REPO_BRANCH == "current" ]; then
     REPO_SUBPATH=$REPO_NAME
   else
     REPO_SUBPATH=$REPO_NAME/$REPO_BRANCH


### PR DESCRIPTION
If the master or current repos are used and someone switches back to
a stable SBo version, sqg will not use the stable version without
deleting the other repo(s) since it simply checks for the .git folder
first. If it is found, it never attempts to switch to the repo set
for sbopkg.

This change adds detection for the "master" and "current" repos and
will ensure sqg uses the proper repo that is set in /etc/sbopkg.conf
or /root/.sbopkg.conf.