### PR TITLE
sqg: Fix 'find' command to work with symlinked REPO_DIR

### DIFF
--- a/src/usr/libexec/sbopkg/sqg/functions
+++ b/src/usr/libexec/sbopkg/sqg/functions
@@ -226,10 +226,10 @@ execute_build () {
   if [ "$ALL" == "yes" ]; then
     rm -f $QUEUEDIR/*.sqf
     printf "Processing all SlackBuilds in the $REPO_SUBPATH repository..."
-    PKGSNEW=($(find "$REPO_DIR" -name "*.info" -print0 | xargs -r0))
+    PKGSNEW=($(find "$REPO_DIR/" -name "*.info" -print0 | xargs -r0))
   else
     for PKG in ${PKGS[@]}; do
-      INFOPATH=$(find "$REPO_DIR" -name ${PKG}.info)
+      INFOPATH=$(find "$REPO_DIR/" -name ${PKG}.info)
 
       if [ -z "$INFOPATH" ]; then
         echo "$PKG: Not found."


### PR DESCRIPTION
I like to have my /var/lib/sbopkg/local/local/ dir be a symlink to a git repo in my home dir. This used to work, but at some point it broke in sqg.

That is:  something like `sqg -p some-package` does not work, even if `some-package.info` exists in the correct hierarchy.

Adding a trailing slash to a couple of the 'find' commands in question makes it work. Adding '-H' to the find command would work as well.