### PR TITLE
Automatically choose pre-specified options in bulk mode (-B)

### DIFF
--- a/src/usr/man/man8/sbopkg.8
+++ b/src/usr/man/man8/sbopkg.8
@@ -231,6 +231,9 @@ time it is encountered.
 .TP
 .B \-B
 Process the packages or queues without prompting for confirmation first.
+.IP
+If options are specified, the order of precedence will be: command line 
+options, options specified in the repository and then queuefile options.
 .\"---------------------------------------------------------------------
 .TP
 .B \-c

--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -3869,47 +3869,71 @@ use_options() {
                 QUEUEOPT=" (Q)ueuefile,"
             fi
             echo
-            while :; do
-                read $NFLAG \
-                    -ep "Use (N)one,$CLI_OPT$SAVEDOPT$QUEUEOPT or (A)bort?: "
-                case $REPLY in
-                    N|n) break ;;
-                    C|c)
-                        if [[ $CLI_OPTIONS ]]; then
-                            BUILDOPTIONS="$CLI_OPTIONS"
-                            cp $CLI_OPTFILE $PKGPATH/options.build
-                            break
-                        fi
-                        ;;
-                    S|s)
-                        if [[ $TMPOPTIONS ]]; then
-                            cp $PKGPATH/options.sbopkg $PKGPATH/options.build
-                            BUILDOPTIONS=$TMPOPTIONS
-                            break
-                        else
-                            echo
-                            crunch_fmt "ERROR:  No saved options found. \
-                                Please make another choice."
-                            echo
-                        fi
-                        ;;
-                    Q|q)
-                        if [[ $LDOPTIONS ]]; then
-                            cp $SBOPKGTMP/sbopkg_"$OPTAPP"_loadoptions \
-                                $PKGPATH/options.build
-                            BUILDOPTIONS=$LDOPTIONS
-                            break
-                        else
-                            echo
-                            crunch_fmt "ERROR:  No queuefile options found. \
-                                Please make another choice."
-                            echo
-                        fi
-                        ;;
-                    A|a) return 1 ;;
-                    *) unknown_response ;;
-                esac
-            done
+            if [[ $BULK ]]; then
+				# When running in BULK mode, use the most specific option by default.
+				# The order of specificity is defined as: Queuefile < Saved < CLI.
+				if [[ $LDOPTIONS ]]; then
+					cp $SBOPKGTMP/sbopkg_"$OPTAPP"_loadoptions \
+						$PKGPATH/options.build
+					BUILDOPTIONS=$LDOPTIONS
+					BULK_OPT="queuefile options: $LDOPTIONS"
+				fi
+				if [[ $TMPOPTIONS ]]; then
+					cp $PKGPATH/options.sbopkg $PKGPATH/options.build
+					BUILDOPTIONS=$TMPOPTIONS
+					BULK_OPT="saved options: $TMPOPTIONS"
+				fi
+				if [[ $CLI_OPTIONS ]]; then
+					BUILDOPTIONS="$CLI_OPTIONS"
+					cp $CLI_OPTFILE $PKGPATH/options.build
+					BULK_OPT="command line options: $CLI_OPTIONS"
+				fi
+				echo "Running in bulk mode."
+				echo "Using $BULK_OPT"
+				unset BULK_OPT
+            else
+				while :; do
+					read $NFLAG \
+						-ep "Use (N)one,$CLI_OPT$SAVEDOPT$QUEUEOPT or (A)bort?: "
+					case $REPLY in
+						N|n) break ;;
+						C|c)
+							if [[ $CLI_OPTIONS ]]; then
+								BUILDOPTIONS="$CLI_OPTIONS"
+								cp $CLI_OPTFILE $PKGPATH/options.build
+								break
+							fi
+							;;
+						S|s)
+							if [[ $TMPOPTIONS ]]; then
+								cp $PKGPATH/options.sbopkg $PKGPATH/options.build
+								BUILDOPTIONS=$TMPOPTIONS
+								break
+							else
+								echo
+								crunch_fmt "ERROR:  No saved options found. \
+									Please make another choice."
+								echo
+							fi
+							;;
+						Q|q)
+							if [[ $LDOPTIONS ]]; then
+								cp $SBOPKGTMP/sbopkg_"$OPTAPP"_loadoptions \
+									$PKGPATH/options.build
+								BUILDOPTIONS=$LDOPTIONS
+								break
+							else
+								echo
+								crunch_fmt "ERROR:  No queuefile options found. \
+									Please make another choice."
+								echo
+							fi
+							;;
+						A|a) return 1 ;;
+						*) unknown_response ;;
+					esac
+				done
+			fi
             echo
         fi
     fi

--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -3870,70 +3870,70 @@ use_options() {
             fi
             echo
             if [[ $BULK ]]; then
-				# When running in BULK mode, use the most specific option by default.
-				# The order of specificity is defined as: Queuefile < Saved < CLI.
-				if [[ $LDOPTIONS ]]; then
-					cp $SBOPKGTMP/sbopkg_"$OPTAPP"_loadoptions \
-						$PKGPATH/options.build
-					BUILDOPTIONS=$LDOPTIONS
-					BULK_OPT="queuefile options: $LDOPTIONS"
-				fi
-				if [[ $TMPOPTIONS ]]; then
-					cp $PKGPATH/options.sbopkg $PKGPATH/options.build
-					BUILDOPTIONS=$TMPOPTIONS
-					BULK_OPT="saved options: $TMPOPTIONS"
-				fi
-				if [[ $CLI_OPTIONS ]]; then
-					BUILDOPTIONS="$CLI_OPTIONS"
-					cp $CLI_OPTFILE $PKGPATH/options.build
-					BULK_OPT="command line options: $CLI_OPTIONS"
-				fi
-				echo "Running in bulk mode."
-				echo "Using $BULK_OPT"
-				unset BULK_OPT
+                # When running in BULK mode, use the most specific option by default.
+                # The order of specificity is defined as: Queuefile < Saved < CLI.
+                if [[ $LDOPTIONS ]]; then
+                    cp $SBOPKGTMP/sbopkg_"$OPTAPP"_loadoptions \
+                        $PKGPATH/options.build
+                    BUILDOPTIONS=$LDOPTIONS
+                    BULK_OPT="queuefile options: $LDOPTIONS"
+                fi
+                if [[ $TMPOPTIONS ]]; then
+                    cp $PKGPATH/options.sbopkg $PKGPATH/options.build
+                    BUILDOPTIONS=$TMPOPTIONS
+                    BULK_OPT="saved options: $TMPOPTIONS"
+                fi
+                if [[ $CLI_OPTIONS ]]; then
+                    BUILDOPTIONS="$CLI_OPTIONS"
+                    cp $CLI_OPTFILE $PKGPATH/options.build
+                    BULK_OPT="command line options: $CLI_OPTIONS"
+                fi
+                echo "Running in bulk mode."
+                echo "Using $BULK_OPT"
+                unset BULK_OPT
             else
-				while :; do
-					read $NFLAG \
-						-ep "Use (N)one,$CLI_OPT$SAVEDOPT$QUEUEOPT or (A)bort?: "
-					case $REPLY in
-						N|n) break ;;
-						C|c)
-							if [[ $CLI_OPTIONS ]]; then
-								BUILDOPTIONS="$CLI_OPTIONS"
-								cp $CLI_OPTFILE $PKGPATH/options.build
-								break
-							fi
-							;;
-						S|s)
-							if [[ $TMPOPTIONS ]]; then
-								cp $PKGPATH/options.sbopkg $PKGPATH/options.build
-								BUILDOPTIONS=$TMPOPTIONS
-								break
-							else
-								echo
-								crunch_fmt "ERROR:  No saved options found. \
-									Please make another choice."
-								echo
-							fi
-							;;
-						Q|q)
-							if [[ $LDOPTIONS ]]; then
-								cp $SBOPKGTMP/sbopkg_"$OPTAPP"_loadoptions \
-									$PKGPATH/options.build
-								BUILDOPTIONS=$LDOPTIONS
-								break
-							else
-								echo
-								crunch_fmt "ERROR:  No queuefile options found. \
-									Please make another choice."
-								echo
-							fi
-							;;
-						A|a) return 1 ;;
-						*) unknown_response ;;
-					esac
-				done
-			fi
+                while :; do
+                    read $NFLAG \
+                        -ep "Use (N)one,$CLI_OPT$SAVEDOPT$QUEUEOPT or (A)bort?: "
+                    case $REPLY in
+                        N|n) break ;;
+                        C|c)
+                            if [[ $CLI_OPTIONS ]]; then
+                                BUILDOPTIONS="$CLI_OPTIONS"
+                                cp $CLI_OPTFILE $PKGPATH/options.build
+                                break
+                            fi
+                            ;;
+                        S|s)
+                            if [[ $TMPOPTIONS ]]; then
+                                cp $PKGPATH/options.sbopkg $PKGPATH/options.build
+                                BUILDOPTIONS=$TMPOPTIONS
+                                break
+                            else
+                                echo
+                                crunch_fmt "ERROR:  No saved options found. \
+                                    Please make another choice."
+                                echo
+                            fi
+                            ;;
+                        Q|q)
+                            if [[ $LDOPTIONS ]]; then
+                                cp $SBOPKGTMP/sbopkg_"$OPTAPP"_loadoptions \
+                                    $PKGPATH/options.build
+                                BUILDOPTIONS=$LDOPTIONS
+                                break
+                            else
+                                echo
+                                crunch_fmt "ERROR:  No queuefile options found. \
+                                    Please make another choice."
+                                echo
+                            fi
+                            ;;
+                        A|a) return 1 ;;
+                        *) unknown_response ;;
+                    esac
+                done
+            fi
             echo
         fi
     fi


### PR DESCRIPTION
Added behaviour to use_options when running in bulk mode to automatically prefer CLI-options over options specified in the user's repository and prefer options specified in the user's repository over options specified in a queue-file if one is used.

The man-page is also updated to document this behaviour.

This saves users a lot of prompts when using the -B flag (bulk mode) while running sbopkg with a queuefile in which a lot of build options have previously been specified. As bulk mode exists to remove lots of prompts, this seemed like an appropriate method to handle this.