### PR TITLE
Add support for URLs with fn=/f= filename parameters 

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -3217,7 +3217,7 @@ get_source() {
 
                 echo "$!" >> $SBOPKG_PIDLIST 2>> $SBOPKGOUTPUT
                 wait $!
-                WGETRC=$
+                WGETRC=$?
             else
                 FAILURE=loop
                 echo "  Download failed. Please report this as a bug." >> \


### PR DESCRIPTION
## Description

This PR adds support for downloading sources from URLs that use query parameters to specify the filename, such as git web interface snapshot URLs (e.g., cgit, gitweb). 
[SBo-issue](https://github.com/SlackBuildsOrg/slackbuilds/issues/13484)

**Example URL:**
```
https://git.cinelerra-gg.org/git/?p=goodguy/cinelerra.git;a=snapshot;h=1914b32;sf=tgz;fn=cinelerra-1914b32.tar.gz
```

## Problem

Previously, sbopkg couldn't properly handle these URLs because:

1. The filename was extracted from the URL path (resulting in `index.html` or the full query string)
2. wget saved the file with the wrong name
3. Symlinks were created with URL query strings in their names
4. SlackBuilds using globs like `tar xvf $CWD/*tar.gz` would match these broken symlinks

## Changes

### 1. `get_source_names()` - Extract filename from URL parameters

Extract filename from `fn=` or `f=` URL parameters instead of using the URL path:

```
if [[ "$DL" =~ [\?\;]fn?=([^\?\;\&]+) ]]; then
    SRCNAME="${BASH_REMATCH[1]}"
fi
```

### 2. `get_source()` - Use `--content-disposition` for wget

Use `--content-disposition` flag for wget when URL has `fn=`/`f=` parameters, so wget respects the server's suggested filename:

```
if [[ "$dl_url" =~ [\?';']fn?= ]]; then
    wget $TWGETFLAGS --content-disposition -- "$dl_url"
else
    wget $TWGETFLAGS -- "$dl_url"
fi
```

### 3. `get_source()` - Clean up broken symlinks

Clean up old broken symlinks with query strings in names:

```
find "$REPO_DIR/$PKGPATH" -maxdepth 1 -type l -name '*\?*' -delete 2>/dev/null
find "$REPO_DIR/$PKGPATH" -maxdepth 1 -type l -name '*;*' -delete 2>/dev/null
```

### 4. `process_package()` - Fix `.info.build` before build

Replace URLs with filenames in `.info.build` after download but before build, so SlackBuilds can find the source files correctly.

## Testing

- Tested with `cinelerra` package which uses git web snapshot URL
- Tested that normal packages without `fn=`/`f=` parameters still work correctly