### PR TITLE
https://github.com/sbopkg/sbopkg/issues/70

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -1470,9 +1470,11 @@ customize_item() {
         "Edit SlackBuild" "Create and edit a local copy of the SlackBuild" \
         "Delete SlackBuild" "Delete the local copy of the SlackBuild" \
         "Diff SlackBuild" "Compare the local and the original SlackBuild" \
+        "Save Diff SlackBuild" "Save diff as patch file" \
         "Edit Info" "Create and edit a local copy of the .info file" \
         "Delete Info" "Delete the local copy of the .info file" \
         "Diff Info" "Compare the local and the original .info file" \
+        "Save Diff Info" "Save diff as patch file" \
         2> $SBOPKGTMP/sbopkg_custom_selection
     if [[ $? = 0 ]]; then
         DEFAULTITEM="$(< $SBOPKGTMP/sbopkg_custom_selection)"
@@ -1494,6 +1496,12 @@ customize_item() {
                 ;;
             "Diff Info" )
                 diff_local_file info $SHORTPATH $APP
+                ;;
+            "Save Diff SlackBuild" )
+                save_diff_local_file SlackBuild "$SHORTPATH" "$APP"
+                ;;
+            "Save Diff Info" )
+                save_diff_local_file info "$SHORTPATH" "$APP"
                 ;;
         esac
     else # Cancel or ESC
@@ -3730,6 +3738,37 @@ diff_local_file() {
             --textbox $DIFF_FILE 0 0
         rm -f $DIFF_FILE
     fi
+}
+
+save_diff_local_file() {
+    # $1 = info|SlackBuild
+    # $2 = application path
+    # $3 = application name
+
+    local FILE=$1
+    local SHORTPATH=$2
+    local APP=$3
+
+    local OUTDIR="/tmp/SBo/$APP"
+    local PATCH_FILE="$OUTDIR/$APP-$FILE.patch"
+
+    mkdir -p "$OUTDIR"
+
+    if [[ ! -e $SHORTPATH/$APP.$FILE.sbopkg ]]; then
+        dialog --title "ERROR" --msgbox \
+            "There is no local copy of the $FILE file to generate a patch." 8 40
+        return 1
+    fi
+
+    $DIFF $DIFFOPTS \
+        "$SHORTPATH/$APP.$FILE" \
+        "$SHORTPATH/$APP.$FILE.sbopkg" \
+        > "$PATCH_FILE"
+
+    dialog --title "Saved" --msgbox \
+        "Patch saved to:\n$PATCH_FILE" 7 60
+
+    return 0
 }
 
 pick_file() {


### PR DESCRIPTION
This is a clean and useful enhancement to the customization workflow. The save_diff_local_file() function integrates well without affecting existing behavior, and the /tmp/SBo/<package>/ output path is appropriate for temporary patch storage. The menu integration is straightforward and consistent with the current design.

Overall, this is a practical improvement that makes it easier to export and share local changes.
<img width="661" height="664" alt="sbopkg-diff2" src="https://github.com/user-attachments/assets/bf867768-0101-44ed-ad55-2747a127f757" />
<img width="1920" height="1080" alt="sbopkg-diff" src="https://github.com/user-attachments/assets/467db2c0-c26c-49bf-bf45-1c9af63d10d0" />


