### PR TITLE
Fix a bug for sqg -p line:5184

### DIFF
--- a/src/usr/sbin/sbopkg
+++ b/src/usr/sbin/sbopkg
@@ -5181,7 +5181,7 @@ else
                             parse_queue $QUEUEDIR/$PKGBUILD.sqf
                         else
                             echo "$SCRIPT: sqg failed to generate queue for $PKGBUILD." >&2
-                            exit 1
+                            parse_arguments "$PKGBUILD"
                         fi
                 else
                     parse_arguments "$PKGBUILD"


### PR DESCRIPTION
This is a bug fix for `sbopkg -k -a -i pkg_name` <br>
When -a try `sqg - p pkg_name` and sqg fails to generate a queue file (i.e. the package has no dependencies), instead of exiting with an error, sbopkg now falls back to a direct install via parse_arguments.
examples: 

before: 
```
sbopkg -k -a -i sl
```
exit 1 (progress stop)

Now can build sl normally as P (Package)